### PR TITLE
Proposed fix to issue#3495

### DIFF
--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -40,7 +40,8 @@ socket.on("msg", function(data) {
 		channel = vueApp.activeChannel.channel;
 
 		data.chan = channel.id;
-	} else if (!isActiveChannel) {
+		//Set unread counter for all channels if tab is inactive
+	} else if (!isActiveChannel || document.hidden) {
 		// Do not set unread counter for channel if it is currently active on this client
 		// It may increase on the server before it processes channel open event from this client
 


### PR DESCRIPTION
Set unread counter for all channels if tab is visible

- The modification includes a check if the tab is visible using the document.hidden API, if not visible unread counters will be set whether or not the channel is active.

This commit resolves #3495

https://github.com/thelounge/thelounge/issues/3495